### PR TITLE
Allow computation of scores w/o TSV file, fix error when using as a package, bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setuptools.setup(
     name="tts-scores",
     packages=["tts_scores"],
-    version="1.0.0",
+    version="1.0.1",
     author="James",
     author_email="james@adamant.ai",
     description="A library for computing performance metrics for text-to-speech systems",

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setuptools.setup(
         'unidecode',
         'inflect',
         'pytorch_fid',
+        'entmax',
         'einops'
     ],
     classifiers=[

--- a/tts_scores/clvp.py
+++ b/tts_scores/clvp.py
@@ -346,6 +346,19 @@ class CLVPMetric:
                 text_codes = torch.tensor(self.tokenizer.encode(text), device=self.device).unsqueeze(0)
                 ces.append(self.model(text_codes, mel, cond_mel, False))
             return torch.stack(ces).mean()
+            
+    def compute_clvp_directly(self, paths_and_text, real_dir, verbose=True):
+        with torch.no_grad():
+            ces = []
+            for path, text in tqdm(paths_and_text, disable=not verbose):
+                audio = load_audio(str(path), 22050).to(self.device)[:1]  # Only take the first channel (if multiple are present)
+                mel = to_mel(audio).unsqueeze(0)
+                real_path = os.path.join(real_dir, os.path.basename(str(path)))
+                cond_audio = load_audio(real_path, 22050).to(self.device)[:1]
+                cond_mel = to_mel(cond_audio).unsqueeze(0)
+                text_codes = torch.tensor(self.tokenizer.encode(text), device=self.device).unsqueeze(0)
+                ces.append(self.model(text_codes, mel, cond_mel, False))
+            return torch.stack(ces).mean()
 
 
 if __name__ == '__main__':

--- a/tts_scores/clvp.py
+++ b/tts_scores/clvp.py
@@ -296,14 +296,14 @@ class CLVP(nn.Module):
 
 
 class CLVPMetric:
-    def __init__(self, device='cpu', pretrained_path='.data/clvp.pth'):
+    def __init__(self, device='cpu', pretrained_path='.data/clvp.pth', tok_path='.data/clvp_tok.json'):
         self.device = device
         self.model = CLVP(model_dim=512, transformer_heads=8, dropout=0, num_text_tokens=256, text_enc_depth=8,
                           text_mask_percentage=0, conditioning_enc_depth=4, speech_enc_depth=8,
                           speech_mask_percentage=0, latent_multiplier=2).eval().to(device)
         sd = torch.load(pretrained_path, map_location=device)
         self.model.load_state_dict(sd)
-        self.tokenizer = VoiceBpeTokenizer()
+        self.tokenizer = VoiceBpeTokenizer(tok_path)
 
     def compute_frechet_distance(self, proj1, proj2):
         # I really REALLY FUCKING HATE that this is going to numpy. I do it because the `pytorch_fid` repo does it and

--- a/tts_scores/tokenizer.py
+++ b/tts_scores/tokenizer.py
@@ -221,8 +221,8 @@ def remove_extraneous_punctuation(word):
 
 
 class VoiceBpeTokenizer:
-    def __init__(self):
-          self.tokenizer = Tokenizer.from_file('.data/clvp_tok.json')
+    def __init__(self, tok_path='.data/clvp_tok.json'):
+          self.tokenizer = Tokenizer.from_file(tok_path)
 
     def preprocess_text(self, txt):
         txt = english_cleaners(txt)

--- a/tts_scores/utils.py
+++ b/tts_scores/utils.py
@@ -24,7 +24,7 @@ def load_audio(audiopath, sampling_rate):
     if audiopath[-4:] == '.wav':
         audio, lsr = load_wav_to_torch(audiopath)
     else:
-        raise RuntimeError
+        raise RuntimeError(f"Audio path {audiopath} does not end with .wav")
 
     # Remove any channel data.
     if len(audio.shape) > 1:


### PR DESCRIPTION
Hi,
This allows computation of scores w/o a TSV file, allows specification of a tokenizer path to prevent an error when using this as a package, and bumps the version to 1.0.1.
If this PR is merged, please update the PyPI package with the latest changes.
Thank you!